### PR TITLE
Tools/get gimp info

### DIFF
--- a/GIMP_MCP_PROTOCOL.md
+++ b/GIMP_MCP_PROTOCOL.md
@@ -27,6 +27,21 @@ Returns comprehensive metadata about the current open image without transferring
 - **Path/vector data**: name, visibility, stroke count
 - **File information**: path, URI, basename (if image was saved)
 
+#### `get_gimp_info()` 
+Returns comprehensive information about the GIMP installation and runtime environment.
+- **Returns**: Dictionary containing detailed GIMP environment information
+- **Performance**: Fast - gathers system information without heavy operations
+- **Use case**: Environment discovery, troubleshooting, capability detection, optimal support
+
+**Returned information includes:**
+- **Version details**: GIMP version string, major/minor/micro versions
+- **Directory paths**: user directory, system data, plugins, locale, sysconf directories
+- **Session information**: number of open images, file paths, basic image properties
+- **PDB capabilities**: Procedure Database availability, sample procedure tests
+- **Current context**: foreground/background colors, brush settings
+- **System capabilities**: Python modules, MCP features, API version
+- **Platform information**: OS details, environment variables, Python version
+
 ### 2. General API Tool
 
 #### `call_api(api_path, args=[], kwargs={})`
@@ -40,8 +55,8 @@ Execute GIMP 3.0 API methods through PyGObject console.
 - Commands execute in persistent context - imports and variables persist
 - Always call Gimp.displays_flush() after drawing operations
 
-For image operations, use `get_image_bitmap()` for full image export or `get_image_metadata()` for fast information gathering.
-Both return MCP-compliant data that AI assistants can process directly.
+For image operations, use `get_image_bitmap()` for full image export, `get_image_metadata()` for fast information gathering, or `get_gimp_info()` for environment discovery.
+All tools return MCP-compliant data that AI assistants can process directly.
 
 ## Basic Method
 
@@ -313,9 +328,80 @@ metadata = get_image_metadata()
 }
 ```
 
+#### Using `get_gimp_info()`
+```python
+# Get comprehensive GIMP environment information
+gimp_info = get_gimp_info()
+
+# Example response structure:
+{
+  "version": {
+    "version_method": "3.1.4",
+    "detected_version": "3.1.4",
+    "available_version_attributes": ["version"],
+    "gimp_module_type": "<class 'gi.module.Gimp'>"
+  },
+  "directories": {
+    "user_directory": "/home/user/.config/GIMP/3.1",
+    "system_data_directory": "/usr/share/gimp/3.1", 
+    "plugin_directory": "/usr/lib/gimp/3.1/plug-ins",
+    "available_directory_methods": ["directory", "data_directory", "plug_in_directory"]
+  },
+  "session": {
+    "num_open_images": 2,
+    "has_open_images": true,
+    "open_image_files": [
+      {
+        "index": 0,
+        "width": 1920,
+        "height": 1080,
+        "base_type": "RGB",
+        "path": "/home/user/photo.jpg",
+        "is_dirty": false
+      }
+    ]
+  },
+  "pdb": {
+    "available": true,
+    "sample_procedures": [
+      {"name": "file-png-export", "available": true},
+      {"name": "gimp-image-new", "available": true}
+    ]
+  },
+  "context": {
+    "foreground_color": "rgba(0,0,0,1)",
+    "background_color": "rgba(255,255,255,1)",
+    "brush_size": 20.0
+  },
+  "capabilities": {
+    "has_python_console": true,
+    "mcp_server_running": true,
+    "supports_image_export": true,
+    "supports_metadata_export": true,
+    "supports_gimp_info": true,
+    "api_version": "3.0+",
+    "gimp_module_attributes": 127,
+    "gimp_methods": ["Brush", "Channel", "Context", "Display", "Drawable"],
+    "available_modules": [
+      {"name": "gi.repository.Gimp", "available": true},
+      {"name": "gi.repository.Gegl", "available": true}
+    ]
+  },
+  "system": {
+    "platform": "Linux-6.2.0-generic-x86_64",
+    "python_version": "3.11.4",
+    "environment_vars": {
+      "HOME": "/home/user",
+      "USER": "user"
+    }
+  }
+}
+```
+
 #### When to Use Each Tool
 - **`get_image_bitmap()`**: When you need to visually analyze or process the actual image
 - **`get_image_metadata()`**: When you need image properties for decision making, validation, or information display
+- **`get_gimp_info()`**: When you need environment information for troubleshooting, capability detection, or optimal support
 
 ## Plugin Architecture
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ uv run --directory /full/path/to/gimp-mcp gimp_mcp_server.py
 ```
 *Uses `get_image_metadata()` to analyze image structure for intelligent decision making*
 
+#### Environment Discovery
+```
+"What version of GIMP am I working with and what features are available?"
+```
+*Uses `get_gimp_info()` to provide comprehensive environment information for optimal support*
+
+#### Troubleshooting Support
+```
+"I'm having issues with plugin exports - check my GIMP setup and suggest solutions"
+```
+*Uses `get_gimp_info()` to diagnose installation and configuration problems*
+
 #### Complex Workflows
 ```
 "Create a new 800x600 image, draw a blue circle in the center, add a red border, then show me the result"
@@ -178,6 +190,9 @@ The GIMP MCP server provides several tools that AI assistants can use:
 ### 🖼️ Image Export Tools
 - **`get_image_bitmap()`**: Get current image as MCP-compliant Image object (PNG format)
 - **`get_image_metadata()`**: Get comprehensive image metadata without bitmap data (fast)
+
+### 🔍 System Information Tool
+- **`get_gimp_info()`**: Get comprehensive GIMP installation and environment information
 
 ### 🔧 API Access Tool  
 - **`call_api(api_path, args, kwargs)`**: Execute any GIMP 3.0 PyGObject command

--- a/gimp_mcp_server.py
+++ b/gimp_mcp_server.py
@@ -140,6 +140,39 @@ def get_image_metadata(ctx: Context) -> dict:
 
 
 @mcp.tool()
+def get_gimp_info(ctx: Context) -> dict:
+    """Get comprehensive information about the GIMP installation and environment.
+    
+    Returns detailed information about GIMP that AI assistants need to understand
+    the current environment, including:
+    - GIMP version and build information
+    - Installation paths and directories
+    - Available plugins and procedures
+    - System configuration
+    - Runtime environment details
+    
+    This information helps AI assistants provide better support and troubleshooting
+    by understanding the specific GIMP setup they're working with.
+    
+    Returns:
+    - Dictionary containing comprehensive GIMP environment information
+    - Raises exception if GIMP connection fails
+    """
+    try:
+        print("Requesting GIMP environment information...")
+        
+        conn = get_gimp_connection()
+        result = conn.send_command("get_gimp_info")
+        if result["status"] == "success":
+            return result["results"]
+        else:
+            raise Exception(f"GIMP error: {result.get('error', 'Unknown error')}")
+    except Exception as e:
+        traceback.print_exc()
+        raise Exception(f"Failed to get GIMP info: {e}")
+
+
+@mcp.tool()
 def call_api(ctx: Context, api_path: str, args: list = [], kwargs: dict = {}) -> str:
     """Call GIMP 3.0 API methods through PyGObject console.
 


### PR DESCRIPTION
This pull request introduces two major new tools to the GIMP MCP server and updates documentation to reflect their usage. The new tools allow fast retrieval of image metadata and comprehensive discovery of the GIMP environment, improving performance and enabling smarter workflows for AI assistants. Documentation in both `README.md` and `GIMP_MCP_PROTOCOL.md` is expanded with usage examples, tool descriptions, and guidance on when to use each tool.

**New API tools:**

* Added `get_image_metadata()` to quickly retrieve detailed metadata about the current image (dimensions, color mode, layers, channels, file info, etc.) without transferring bitmap data, enabling faster analysis and decision making.
* Added `get_gimp_info()` to provide comprehensive information about the GIMP installation and runtime environment, including version, directories, plugins, session info, system capabilities, and more, for troubleshooting and optimal support.

**Documentation updates:**

_Image and system info tool usage:_

* Updated `GIMP_MCP_PROTOCOL.md` to document `get_image_metadata()` and `get_gimp_info()`, including their returned data structures, performance characteristics, and recommended use cases. [[1]](diffhunk://#diff-70ec387065797844df29baee52c6c1d1d3b052ab2c7a96967350083dda9373fcR16-R44) [[2]](diffhunk://#diff-70ec387065797844df29baee52c6c1d1d3b052ab2c7a96967350083dda9373fcR283-R405)
* Clarified the distinction between `get_image_bitmap()`, `get_image_metadata()`, and `get_gimp_info()` for various image and environment operations, and emphasized MCP-compliant outputs for AI assistants.

_Examples and tool listing:_

* Expanded `README.md` with practical examples for fast image info, smart workflow decisions, environment discovery, and troubleshooting using the new tools.
* Updated the tool listing in `README.md` to include `get_image_metadata()` and `get_gimp_info()` under their respective sections.