### PR TITLE
Update stale 'GIMP 3.0' references + verify Python 3.14 (closes #13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a GIMP MCP (Model Context Protocol) integration that enables external control of GIMP 3.0 through Claude Desktop and other MCP clients. The system consists of two main components:
+This is a GIMP MCP (Model Context Protocol) integration that enables external control of GIMP 3.2 through Claude Desktop and other MCP clients. The system consists of two main components:
 
-1. **GIMP Plugin** (`gimp-mcp-plugin.py`): A GIMP 3.0 plugin that starts a socket server inside GIMP
+1. **GIMP Plugin** (`gimp-mcp-plugin.py`): A GIMP 3.2 plugin that starts a socket server inside GIMP
 2. **MCP Server** (`gimp-mcp-server.py`): An MCP server that connects to the GIMP plugin and exposes GIMP functionality
 
 ## Architecture
@@ -14,7 +14,7 @@ This is a GIMP MCP (Model Context Protocol) integration that enables external co
 The system uses a client-server architecture:
 - GIMP Plugin creates a socket server (localhost:9877) that accepts Python-Fu commands
 - MCP Server connects to this socket and exposes a `call_api` tool for MCP clients
-- Commands are executed in GIMP's Python-Fu environment with access to the full GIMP 3.0 API
+- Commands are executed in GIMP's Python-Fu environment with access to the full GIMP 3.2 API
 
 ## Installation & Setup
 
@@ -60,7 +60,7 @@ The main interface is the `call_api` tool with parameters:
 }
 ```
 
-### GIMP 3.0 API Key Points
+### GIMP 3.2 API Key Points
 
 - Use `Gimp.get_images()` instead of deprecated `Gimp.list_images()`
 - Access layers via `image.get_layers()` instead of `Gimp.get_active_layer()`
@@ -103,9 +103,9 @@ Gimp.displays_flush()
 ## Important Notes
 
 - Commands execute in a persistent Python context - imports and variables persist between calls
-- GIMP 3.0 API differs significantly from 2.x - consult https://developer.gimp.org/api/3.0/libgimp/
+- GIMP 3.2 API differs significantly from 2.x - consult https://developer.gimp.org/api/3.0/libgimp/
 - Always verify API calls work before building complex operations
-- The `gimpfu` module is not available in GIMP 3.0
+- The `gimpfu` module is not available in GIMP 3.2
 - Use proper error handling as socket connections can fail
 
 ## File Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "gimp-mcp"
 version = "0.1.0"
-description = "GIMP MCP integration for external control of GIMP 3.0"
+description = "GIMP MCP integration for external control of GIMP 3.2"
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- `pyproject.toml` description: "GIMP 3.0" → "GIMP 3.2"
- `CLAUDE.md`: 6 occurrences of "GIMP 3.0" → "GIMP 3.2" (preserves the `api/3.0/libgimp/` URL and `/GIMP/3.0/plug-ins/` install paths — those are GIMP conventions across the whole 3.x series)

## Python 3.14 (second part of #13)

The reporter hit a PyO3 source-build error on 3.14 back in March. Verified today that it's self-resolved upstream:

- `pydantic-core 2.46.1` ships 3.14 wheels
- `mcp 1.27.0` + `fastmcp 3.2.4` install and import cleanly on 3.14

No `requires-python` cap needed. Anyone who still hits the original error just needs a fresh `uv sync --upgrade` (or a clean lock).

## Test plan
- [x] `ruff check` clean
- [x] Fresh `uv pip install mcp fastmcp` on Python 3.14 succeeds and imports work