### PR TITLE
Fix pyproject.toml build errors breaking uv run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "gimp-mcp"
 version = "0.1.0"
 description = "GIMP MCP integration for external control of GIMP 3.2"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "mcp",
@@ -16,6 +17,9 @@ dependencies = [
 
 [project.scripts]
 gimp-mcp-server = "gimp_mcp_server:main"
+
+[tool.setuptools]
+py-modules = ["gimp_mcp_server"]
 
 [tool.ruff.lint.per-file-ignores]
 "gimp-mcp-plugin.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
- Replace deprecated `license = {file = "LICENSE"}` table format with SPDX string `license = "MIT"` and `license-files`, fixing the `SetuptoolsDeprecationWarning`
- Add explicit `py-modules = ["gimp_mcp_server"]` to prevent setuptools flat-layout auto-discovery from failing when multiple top-level `.py` files exist (`bg_remove`, `run_tests`, `agent_edit_demo`, etc.)

## Test plan
- [ ] Verify `uv run python --version` succeeds without build errors
- [ ] Verify `uv run gimp-mcp-server` still starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license metadata to use explicit SPDX identifier format.
  * Refined build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->