### PR TITLE
Silence GIMP 3.x i18n warnings on plugin load

### DIFF
--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -57,6 +57,11 @@ class MCPPlugin(Gimp.PlugIn):
         exec("from gi.repository import Gimp", self.context)
         self.auto_disconnect_client = True
 
+    def do_set_i18n(self, procname):
+        # Plugin has no translations; tell GIMP so it stops logging
+        # "catalog directory does not exist" for every registered procedure.
+        return False
+
     def do_query_procedures(self):
         """Register the plugin procedures."""
         return ["plug-in-mcp-server", "plug-in-mcp-check", "plug-in-mcp-restart"]


### PR DESCRIPTION
## Problem

On GIMP 3.x startup, for every registered procedure that doesn't explicitly override `set_i18n()`, GIMP logs three warning lines:

```
[plug-in-mcp-server] The catalog directory does not exist: ~/.config/GIMP/3.2/plug-ins/gimp-mcp-plugin/locale
[plug-in-mcp-server] Override method set_i18n() for the plug-in to customize or disable localization.
[plug-in-mcp-server] Localization disabled
```

The plugin registers three procedures (`plug-in-mcp-server`, `plug-in-mcp-check`, `plug-in-mcp-restart`), so that's 9 noise lines on every launch.

## Fix

Override `do_set_i18n` on `MCPPlugin` to return `False`. No behavior change — localization was already disabled, this just tells GIMP it's intentional.

## Test plan
- [x] `ruff check` clean
- [ ] Restart GIMP after install, confirm the 9 lines are gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified plugin internationalization behavior to prevent GIMP from automatically translating plugin procedures, providing explicit control over translation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->