### PR TITLE
Fix add_text placeholder metadata on GIMP 3.2 (#15)

### DIFF
--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -3046,21 +3046,36 @@ class MCPPlugin(Gimp.PlugIn):
                             font_obj = flist[0]
 
                 # Path 1 — native GIMP 3 API: Gimp.TextLayer.new
+                # IMPORTANT: once insert_layer has succeeded, commit to this
+                # layer immediately. Post-create steps (set_offsets, color)
+                # are best-effort — a failure there must not cause the PDB
+                # fallback below to run and insert a *second* text layer.
                 if font_obj is not None and hasattr(Gimp, "TextLayer"):
+                    tl = None
                     try:
                         tl = Gimp.TextLayer.new(image, text_str, font_obj, float(size), Gimp.Unit.pixel())
-                        if tl is not None:
+                    except Exception:
+                        tl = None
+                    if tl is not None:
+                        try:
                             image.insert_layer(tl, None, 0)
-                            tl.set_offsets(x, y)
+                            text_layer = tl   # committed — no fallback past here
+                        except Exception:
+                            tl = None
+                    if text_layer is not None:
+                        try:
+                            text_layer.set_offsets(x, y)
+                        except Exception:
+                            pass
+                        try:
                             cproc = pdb.lookup_procedure("gimp-text-layer-set-color")
                             if cproc:
                                 ccfg = cproc.create_config()
-                                ccfg.set_property("layer", tl)
+                                ccfg.set_property("layer", text_layer)
                                 ccfg.set_property("color", Gegl.Color.new(color_str))
                                 cproc.run(ccfg)
-                            text_layer = tl
-                    except Exception:
-                        text_layer = None
+                        except Exception:
+                            pass
 
                 # Path 2 — PDB gimp-text-font (GIMP 3.x; takes GimpFont object)
                 if text_layer is None and font_obj is not None:

--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -2994,7 +2994,13 @@ class MCPPlugin(Gimp.PlugIn):
     # =========================================================================
 
     def _add_text(self, params):
-        """Add a text layer."""
+        """Add a text layer.
+
+        Returns real layer metadata (id, name, width, height) for the newly
+        created text layer so clients can chain follow-up operations by name
+        or id. Never returns placeholder values on success — if the layer
+        cannot be introspected, the call reports status=error.
+        """
         try:
             from gi.repository import Gegl
             image_index = int(params.get("image_index", 0))
@@ -3005,39 +3011,98 @@ class MCPPlugin(Gimp.PlugIn):
             size        = int(params.get("size", 24))
             color_str   = params.get("color", "black")
             image = self._get_image(image_index)
+
+            # Snapshot layer IDs before creation so we can identify the new
+            # text layer even when PDB return-value unpacking varies across
+            # GIMP 3.x point releases.
+            before_ids = {lyr.get_id() for lyr in image.get_layers()}
+
+            text_layer = None
             image.undo_group_start()
             Gimp.context_push()
             try:
                 Gimp.context_set_foreground(Gegl.Color.new(color_str))
-                # Gimp.text_fontname() removed in GIMP 3 — use PDB procedure
                 pdb = Gimp.get_pdb()
-                proc = pdb.lookup_procedure("gimp-text-fontname")
-                text_layer = None
-                if proc:
-                    cfg = proc.create_config()
-                    cfg.set_property("image",     image)
-                    cfg.set_property("drawable",  None)
-                    cfg.set_property("x",         float(x))
-                    cfg.set_property("y",         float(y))
-                    cfg.set_property("text",      text_str)
-                    cfg.set_property("border",    0)
-                    cfg.set_property("antialias", True)
-                    cfg.set_property("size",      float(size))
-                    cfg.set_property("fontname",  font)
-                    result = proc.run(cfg)
-                    if result:
-                        text_layer = result.index(1)
+
+                # Resolve font name → Gimp.Font object, with fallbacks for
+                # legacy aliases ("Sans" was the GIMP 2.x default; in 3.2 the
+                # matching font is "Sans-serif"). If nothing matches, fall
+                # back to the first available font so add_text never fails
+                # purely because a font name is stale.
+                font_obj = None
+                if hasattr(Gimp, "Font") and hasattr(Gimp.Font, "get_by_name"):
+                    font_obj = Gimp.Font.get_by_name(font)
+                    if font_obj is None:
+                        for alias in (font + "-serif", font + " Regular",
+                                      font.replace(" ", "-"),
+                                      "Sans-serif", "Serif", "Monospace"):
+                            font_obj = Gimp.Font.get_by_name(alias)
+                            if font_obj is not None:
+                                break
+                    if font_obj is None:
+                        raw = Gimp.fonts_get_list("")
+                        flist = list(raw[1]) if isinstance(raw, tuple) and len(raw) > 1 else list(raw)
+                        if flist:
+                            font_obj = flist[0]
+
+                # Path 1 — native GIMP 3 API: Gimp.TextLayer.new
+                if font_obj is not None and hasattr(Gimp, "TextLayer"):
+                    try:
+                        tl = Gimp.TextLayer.new(image, text_str, font_obj, float(size), Gimp.Unit.pixel())
+                        if tl is not None:
+                            image.insert_layer(tl, None, 0)
+                            tl.set_offsets(x, y)
+                            cproc = pdb.lookup_procedure("gimp-text-layer-set-color")
+                            if cproc:
+                                ccfg = cproc.create_config()
+                                ccfg.set_property("layer", tl)
+                                ccfg.set_property("color", Gegl.Color.new(color_str))
+                                cproc.run(ccfg)
+                            text_layer = tl
+                    except Exception:
+                        text_layer = None
+
+                # Path 2 — PDB gimp-text-font (GIMP 3.x; takes GimpFont object)
+                if text_layer is None and font_obj is not None:
+                    proc = pdb.lookup_procedure("gimp-text-font")
+                    if proc:
+                        cfg = proc.create_config()
+                        cfg.set_property("image",     image)
+                        cfg.set_property("drawable",  None)
+                        cfg.set_property("x",         float(x))
+                        cfg.set_property("y",         float(y))
+                        cfg.set_property("text",      text_str)
+                        cfg.set_property("border",    0)
+                        cfg.set_property("antialias", True)
+                        cfg.set_property("size",      float(size))
+                        cfg.set_property("font",      font_obj)
+                        proc.run(cfg)
             finally:
                 Gimp.context_pop()
                 image.undo_group_end()
             Gimp.displays_flush()
+
+            # If the fallback path ran (or native path returned None), locate
+            # the newly inserted layer by diffing against the pre-snapshot.
+            if text_layer is None:
+                for lyr in image.get_layers():
+                    if lyr.get_id() not in before_ids:
+                        text_layer = lyr
+                        break
+
+            if text_layer is None:
+                return {
+                    "status": "error",
+                    "error":  "add_text: no text layer was created (no PDB procedure succeeded)",
+                }
+
             return {
                 "status": "success",
                 "results": {
-                    "layer_name":  text_layer.get_name() if text_layer else "unknown",
-                    "layer_id":    text_layer.get_id()   if text_layer else -1,
-                    "text_width":  text_layer.get_width()  if text_layer else 0,
-                    "text_height": text_layer.get_height() if text_layer else 0,
+                    "layer_name":  text_layer.get_name(),
+                    "layer_id":    text_layer.get_id(),
+                    "text_width":  text_layer.get_width(),
+                    "text_height": text_layer.get_height(),
                     "position":    [x, y],
                 }
             }

--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -2993,13 +2993,157 @@ class MCPPlugin(Gimp.PlugIn):
     # CATEGORY 7 — Text
     # =========================================================================
 
-    def _add_text(self, params):
-        """Add a text layer.
+    # ── add_text helpers ─────────────────────────────────────────────────
+    #
+    # _add_text is split into small helpers below so each stage of text
+    # layer creation can be read, reviewed, and reasoned about in isolation.
+    # The flow is:
+    #
+    #     resolve font  ──▶  try native API  ──▶  try PDB fallback
+    #                                │                    │
+    #                                └── layer committed ─┴──▶  find by diff
+    #                                                               │
+    #                                                               ▼
+    #                                                     return metadata
+    #
+    # ─────────────────────────────────────────────────────────────────────
 
-        Returns real layer metadata (id, name, width, height) for the newly
-        created text layer so clients can chain follow-up operations by name
-        or id. Never returns placeholder values on success — if the layer
-        cannot be introspected, the call reports status=error.
+    def _resolve_font(self, name):
+        """Return a ``Gimp.Font`` matching ``name``, or a sensible default.
+
+        Font resolution in GIMP 3.2 is exact-match by display name and does
+        not accept legacy GIMP 2.x aliases. ``"Sans"`` — the old default —
+        no longer matches anything (the 3.2 equivalent is ``"Sans-serif"``).
+
+        To keep ``add_text`` robust against stale font names we try, in
+        order:
+
+        1. Exact match on ``name``.
+        2. Common aliases derived from ``name`` (``"<name>-serif"``,
+           ``"<name> Regular"``, hyphenated).
+        3. Well-known GIMP 3.2 fonts (``"Sans-serif"``, ``"Serif"``,
+           ``"Monospace"``).
+        4. The first font reported by ``Gimp.fonts_get_list("")``.
+
+        Returns ``None`` only if GIMP has no fonts loaded at all.
+        """
+        if not (hasattr(Gimp, "Font") and hasattr(Gimp.Font, "get_by_name")):
+            return None
+
+        font_obj = Gimp.Font.get_by_name(name)
+        if font_obj is not None:
+            return font_obj
+
+        for alias in (name + "-serif", name + " Regular",
+                      name.replace(" ", "-"),
+                      "Sans-serif", "Serif", "Monospace"):
+            font_obj = Gimp.Font.get_by_name(alias)
+            if font_obj is not None:
+                return font_obj
+
+        raw = Gimp.fonts_get_list("")
+        flist = list(raw[1]) if isinstance(raw, tuple) and len(raw) > 1 else list(raw)
+        return flist[0] if flist else None
+
+    def _create_text_layer_native(self, image, text, font_obj, size, x, y, color_str):
+        """Create a text layer via the native GIMP 3 API.
+
+        Uses ``Gimp.TextLayer.new`` + ``image.insert_layer`` + offsets +
+        a ``gimp-text-layer-set-color`` PDB call for styling.
+
+        Returns the inserted layer, or ``None`` if creation failed before
+        ``insert_layer`` succeeded. Once the layer is inserted into the
+        image it is considered committed; post-insert failures (offset,
+        color) are swallowed rather than propagated, so the caller never
+        sees ``None`` for a layer that is actually in the image — which
+        would otherwise cause the PDB fallback to add a *second* layer.
+        """
+        from gi.repository import Gegl
+        if not hasattr(Gimp, "TextLayer"):
+            return None
+
+        try:
+            tl = Gimp.TextLayer.new(image, text, font_obj, float(size), Gimp.Unit.pixel())
+        except Exception:
+            return None
+        if tl is None:
+            return None
+
+        try:
+            image.insert_layer(tl, None, 0)
+        except Exception:
+            return None
+
+        # Layer is committed — style is best-effort from here on.
+        try:
+            tl.set_offsets(x, y)
+        except Exception:
+            pass
+        try:
+            pdb   = Gimp.get_pdb()
+            cproc = pdb.lookup_procedure("gimp-text-layer-set-color")
+            if cproc:
+                ccfg = cproc.create_config()
+                ccfg.set_property("layer", tl)
+                ccfg.set_property("color", Gegl.Color.new(color_str))
+                cproc.run(ccfg)
+        except Exception:
+            pass
+        return tl
+
+    def _create_text_layer_pdb(self, image, text, font_obj, size, x, y):
+        """Create a text layer via the ``gimp-text-font`` PDB procedure.
+
+        ``gimp-text-font`` is the GIMP 3.x replacement for the GIMP 2.x
+        ``gimp-text-fontname``. It takes a ``GimpFont`` object (not a
+        string) and inserts a new text layer into ``image``. The layer
+        handle is not returned directly; callers locate it via a
+        before/after layer-id diff.
+        """
+        proc = Gimp.get_pdb().lookup_procedure("gimp-text-font")
+        if proc is None:
+            return
+        cfg = proc.create_config()
+        cfg.set_property("image",     image)
+        cfg.set_property("drawable",  None)
+        cfg.set_property("x",         float(x))
+        cfg.set_property("y",         float(y))
+        cfg.set_property("text",      text)
+        cfg.set_property("border",    0)
+        cfg.set_property("antialias", True)
+        cfg.set_property("size",      float(size))
+        cfg.set_property("font",      font_obj)
+        proc.run(cfg)
+
+    def _find_new_layer(self, image, before_ids):
+        """Return the first layer in ``image`` whose id is not in ``before_ids``.
+
+        Used to locate a layer inserted by a PDB procedure whose return
+        tuple shape varies across GIMP 3.x point releases.
+        """
+        for lyr in image.get_layers():
+            if lyr.get_id() not in before_ids:
+                return lyr
+        return None
+
+    def _add_text(self, params):
+        """Add a text layer and return its real metadata.
+
+        Flow (see the helpers above for details):
+
+            1. Resolve the requested font name to a ``Gimp.Font``.
+            2. Try ``Gimp.TextLayer.new`` (native, preferred).
+            3. If the native path did not commit a layer, try the
+               ``gimp-text-font`` PDB procedure.
+            4. If neither path returned a handle directly, find the new
+               layer via a before/after id diff.
+            5. Return ``layer_id``, ``layer_name``, ``text_width``,
+               ``text_height`` for the new layer.
+
+        Returns ``status=error`` — never success with placeholder values —
+        when no text layer was actually created. This is the core guard
+        for issue #15: clients must be able to chain subsequent
+        operations on the returned handle.
         """
         try:
             from gi.repository import Gegl
@@ -3010,101 +3154,29 @@ class MCPPlugin(Gimp.PlugIn):
             font        = params.get("font", "Sans")
             size        = int(params.get("size", 24))
             color_str   = params.get("color", "black")
-            image = self._get_image(image_index)
 
-            # Snapshot layer IDs before creation so we can identify the new
-            # text layer even when PDB return-value unpacking varies across
-            # GIMP 3.x point releases.
+            image      = self._get_image(image_index)
             before_ids = {lyr.get_id() for lyr in image.get_layers()}
-
             text_layer = None
+
             image.undo_group_start()
             Gimp.context_push()
             try:
                 Gimp.context_set_foreground(Gegl.Color.new(color_str))
-                pdb = Gimp.get_pdb()
-
-                # Resolve font name → Gimp.Font object, with fallbacks for
-                # legacy aliases ("Sans" was the GIMP 2.x default; in 3.2 the
-                # matching font is "Sans-serif"). If nothing matches, fall
-                # back to the first available font so add_text never fails
-                # purely because a font name is stale.
-                font_obj = None
-                if hasattr(Gimp, "Font") and hasattr(Gimp.Font, "get_by_name"):
-                    font_obj = Gimp.Font.get_by_name(font)
-                    if font_obj is None:
-                        for alias in (font + "-serif", font + " Regular",
-                                      font.replace(" ", "-"),
-                                      "Sans-serif", "Serif", "Monospace"):
-                            font_obj = Gimp.Font.get_by_name(alias)
-                            if font_obj is not None:
-                                break
-                    if font_obj is None:
-                        raw = Gimp.fonts_get_list("")
-                        flist = list(raw[1]) if isinstance(raw, tuple) and len(raw) > 1 else list(raw)
-                        if flist:
-                            font_obj = flist[0]
-
-                # Path 1 — native GIMP 3 API: Gimp.TextLayer.new
-                # IMPORTANT: once insert_layer has succeeded, commit to this
-                # layer immediately. Post-create steps (set_offsets, color)
-                # are best-effort — a failure there must not cause the PDB
-                # fallback below to run and insert a *second* text layer.
-                if font_obj is not None and hasattr(Gimp, "TextLayer"):
-                    tl = None
-                    try:
-                        tl = Gimp.TextLayer.new(image, text_str, font_obj, float(size), Gimp.Unit.pixel())
-                    except Exception:
-                        tl = None
-                    if tl is not None:
-                        try:
-                            image.insert_layer(tl, None, 0)
-                            text_layer = tl   # committed — no fallback past here
-                        except Exception:
-                            tl = None
-                    if text_layer is not None:
-                        try:
-                            text_layer.set_offsets(x, y)
-                        except Exception:
-                            pass
-                        try:
-                            cproc = pdb.lookup_procedure("gimp-text-layer-set-color")
-                            if cproc:
-                                ccfg = cproc.create_config()
-                                ccfg.set_property("layer", text_layer)
-                                ccfg.set_property("color", Gegl.Color.new(color_str))
-                                cproc.run(ccfg)
-                        except Exception:
-                            pass
-
-                # Path 2 — PDB gimp-text-font (GIMP 3.x; takes GimpFont object)
-                if text_layer is None and font_obj is not None:
-                    proc = pdb.lookup_procedure("gimp-text-font")
-                    if proc:
-                        cfg = proc.create_config()
-                        cfg.set_property("image",     image)
-                        cfg.set_property("drawable",  None)
-                        cfg.set_property("x",         float(x))
-                        cfg.set_property("y",         float(y))
-                        cfg.set_property("text",      text_str)
-                        cfg.set_property("border",    0)
-                        cfg.set_property("antialias", True)
-                        cfg.set_property("size",      float(size))
-                        cfg.set_property("font",      font_obj)
-                        proc.run(cfg)
+                font_obj = self._resolve_font(font)
+                if font_obj is not None:
+                    text_layer = self._create_text_layer_native(
+                        image, text_str, font_obj, size, x, y, color_str)
+                    if text_layer is None:
+                        self._create_text_layer_pdb(
+                            image, text_str, font_obj, size, x, y)
             finally:
                 Gimp.context_pop()
                 image.undo_group_end()
             Gimp.displays_flush()
 
-            # If the fallback path ran (or native path returned None), locate
-            # the newly inserted layer by diffing against the pre-snapshot.
             if text_layer is None:
-                for lyr in image.get_layers():
-                    if lyr.get_id() not in before_ids:
-                        text_layer = lyr
-                        break
-
+                text_layer = self._find_new_layer(image, before_ids)
             if text_layer is None:
                 return {
                     "status": "error",

--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -2993,40 +2993,8 @@ class MCPPlugin(Gimp.PlugIn):
     # CATEGORY 7 — Text
     # =========================================================================
 
-    # ── add_text helpers ─────────────────────────────────────────────────
-    #
-    # _add_text is split into small helpers below so each stage of text
-    # layer creation can be read, reviewed, and reasoned about in isolation.
-    # The flow is:
-    #
-    #     resolve font  ──▶  try native API  ──▶  try PDB fallback
-    #                                │                    │
-    #                                └── layer committed ─┴──▶  find by diff
-    #                                                               │
-    #                                                               ▼
-    #                                                     return metadata
-    #
-    # ─────────────────────────────────────────────────────────────────────
-
     def _resolve_font(self, name):
-        """Return a ``Gimp.Font`` matching ``name``, or a sensible default.
-
-        Font resolution in GIMP 3.2 is exact-match by display name and does
-        not accept legacy GIMP 2.x aliases. ``"Sans"`` — the old default —
-        no longer matches anything (the 3.2 equivalent is ``"Sans-serif"``).
-
-        To keep ``add_text`` robust against stale font names we try, in
-        order:
-
-        1. Exact match on ``name``.
-        2. Common aliases derived from ``name`` (``"<name>-serif"``,
-           ``"<name> Regular"``, hyphenated).
-        3. Well-known GIMP 3.2 fonts (``"Sans-serif"``, ``"Serif"``,
-           ``"Monospace"``).
-        4. The first font reported by ``Gimp.fonts_get_list("")``.
-
-        Returns ``None`` only if GIMP has no fonts loaded at all.
-        """
+        """Resolve a font name to a Gimp.Font."""
         if not (hasattr(Gimp, "Font") and hasattr(Gimp.Font, "get_by_name")):
             return None
 
@@ -3034,6 +3002,8 @@ class MCPPlugin(Gimp.PlugIn):
         if font_obj is not None:
             return font_obj
 
+        # GIMP 3.2 dropped GIMP 2.x aliases; e.g. "Sans" no longer resolves,
+        # the 3.2 equivalent is "Sans-serif".
         for alias in (name + "-serif", name + " Regular",
                       name.replace(" ", "-"),
                       "Sans-serif", "Serif", "Monospace"):
@@ -3046,18 +3016,7 @@ class MCPPlugin(Gimp.PlugIn):
         return flist[0] if flist else None
 
     def _create_text_layer_native(self, image, text, font_obj, size, x, y, color_str):
-        """Create a text layer via the native GIMP 3 API.
-
-        Uses ``Gimp.TextLayer.new`` + ``image.insert_layer`` + offsets +
-        a ``gimp-text-layer-set-color`` PDB call for styling.
-
-        Returns the inserted layer, or ``None`` if creation failed before
-        ``insert_layer`` succeeded. Once the layer is inserted into the
-        image it is considered committed; post-insert failures (offset,
-        color) are swallowed rather than propagated, so the caller never
-        sees ``None`` for a layer that is actually in the image — which
-        would otherwise cause the PDB fallback to add a *second* layer.
-        """
+        """Create a text layer via Gimp.TextLayer.new."""
         from gi.repository import Gegl
         if not hasattr(Gimp, "TextLayer"):
             return None
@@ -3074,7 +3033,9 @@ class MCPPlugin(Gimp.PlugIn):
         except Exception:
             return None
 
-        # Layer is committed — style is best-effort from here on.
+        # Layer is now in the image; swallow offset/color failures so the
+        # caller does not fall through to the PDB fallback and insert a
+        # second layer.
         try:
             tl.set_offsets(x, y)
         except Exception:
@@ -3092,14 +3053,7 @@ class MCPPlugin(Gimp.PlugIn):
         return tl
 
     def _create_text_layer_pdb(self, image, text, font_obj, size, x, y):
-        """Create a text layer via the ``gimp-text-font`` PDB procedure.
-
-        ``gimp-text-font`` is the GIMP 3.x replacement for the GIMP 2.x
-        ``gimp-text-fontname``. It takes a ``GimpFont`` object (not a
-        string) and inserts a new text layer into ``image``. The layer
-        handle is not returned directly; callers locate it via a
-        before/after layer-id diff.
-        """
+        """Create a text layer via the gimp-text-font PDB procedure."""
         proc = Gimp.get_pdb().lookup_procedure("gimp-text-font")
         if proc is None:
             return
@@ -3116,35 +3070,14 @@ class MCPPlugin(Gimp.PlugIn):
         proc.run(cfg)
 
     def _find_new_layer(self, image, before_ids):
-        """Return the first layer in ``image`` whose id is not in ``before_ids``.
-
-        Used to locate a layer inserted by a PDB procedure whose return
-        tuple shape varies across GIMP 3.x point releases.
-        """
+        """Return the first layer whose id is not in before_ids."""
         for lyr in image.get_layers():
             if lyr.get_id() not in before_ids:
                 return lyr
         return None
 
     def _add_text(self, params):
-        """Add a text layer and return its real metadata.
-
-        Flow (see the helpers above for details):
-
-            1. Resolve the requested font name to a ``Gimp.Font``.
-            2. Try ``Gimp.TextLayer.new`` (native, preferred).
-            3. If the native path did not commit a layer, try the
-               ``gimp-text-font`` PDB procedure.
-            4. If neither path returned a handle directly, find the new
-               layer via a before/after id diff.
-            5. Return ``layer_id``, ``layer_name``, ``text_width``,
-               ``text_height`` for the new layer.
-
-        Returns ``status=error`` — never success with placeholder values —
-        when no text layer was actually created. This is the core guard
-        for issue #15: clients must be able to chain subsequent
-        operations on the returned handle.
-        """
+        """Add a text layer."""
         try:
             from gi.repository import Gegl
             image_index = int(params.get("image_index", 0))
@@ -3178,6 +3111,8 @@ class MCPPlugin(Gimp.PlugIn):
             if text_layer is None:
                 text_layer = self._find_new_layer(image, before_ids)
             if text_layer is None:
+                # Issue #15: return an explicit error instead of a placeholder
+                # success so clients never chain ops on a fake handle.
                 return {
                     "status": "error",
                     "error":  "add_text: no text layer was created (no PDB procedure succeeded)",

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -156,6 +156,10 @@ def call_add_text(target_index):
 def assert_real_metadata(results):
     """Verify ``add_text`` returned real values, not issue #15 placeholders.
 
+    ``layer_id`` must be **strictly positive**. A real ``Gimp.Drawable``
+    id is never 0, so accepting 0 would let a default-int return slip
+    through the check just as the old ``-1`` sentinel did.
+
     Returns ``(layer_id, layer_name, text_width, text_height)`` on
     success; aborts via :func:`fail` on any placeholder.
     """
@@ -164,7 +168,7 @@ def assert_real_metadata(results):
     text_w     = results.get('text_width')
     text_h     = results.get('text_height')
 
-    if not isinstance(layer_id, int) or layer_id < 0:
+    if not isinstance(layer_id, int) or layer_id <= 0:
         fail(f"layer_id is placeholder: {layer_id!r} (expected positive int)")
     if not layer_name or layer_name == 'unknown':
         fail(f"layer_name is placeholder: {layer_name!r}")
@@ -178,9 +182,15 @@ def assert_real_metadata(results):
 def assert_chainable(target_index, layer_id, layer_name):
     """Verify the returned handle is visible to ``list_layers``.
 
+    Requires a single listed layer whose ``id`` **and** ``name`` both
+    match the metadata we got back. Matching on either-or would happily
+    succeed against an unrelated layer that happens to share a
+    (non-unique) name, which could mask a real bug where the returned
+    ``id`` does not resolve to the new text layer.
+
     The whole point of issue #15 is that clients must be able to chain
-    further operations on the new text layer. If ``list_layers`` can find
-    a layer matching the returned id/name, the handle is usable.
+    further operations on the new text layer — only a full id+name
+    match actually proves that.
     """
     ll = cmd('list_layers', {'image_index': target_index})
     if ll.get('status') != 'success':
@@ -188,7 +198,7 @@ def assert_chainable(target_index, layer_id, layer_name):
 
     layers = (ll.get('results') or {}).get('layers') or []
     match  = next((lyr for lyr in layers
-                   if lyr.get('id') == layer_id or lyr.get('name') == layer_name),
+                   if lyr.get('id') == layer_id and lyr.get('name') == layer_name),
                   None)
     if match is None:
         fail(f"returned layer (id={layer_id}, name={layer_name!r}) not in list_layers: {layers}")

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -1,30 +1,7 @@
 #!/usr/bin/env python3
 """Regression test for issue #15 — add_text must return real layer metadata.
 
-Before the fix, ``_add_text`` returned placeholder values when PDB
-return-value unpacking failed::
-
-    {'layer_name': 'unknown', 'layer_id': -1, 'text_width': 0, ...}
-
-while ``status`` was still ``'success'``, so any follow-up op targeting
-the layer by id/name would fail silently.
-
-What this test proves
----------------------
-
-1. ``add_text`` responds with ``status == 'success'``.
-2. The returned ``layer_id``/``layer_name``/``text_width``/``text_height``
-   are **real values**, not the old ``-1`` / ``'unknown'`` / ``0``
-   sentinels.
-3. ``list_layers`` can see a layer that matches the returned id *and*
-   name — proving the handle is actually chainable, which is the whole
-   point of issue #15.
-
-The test reuses the character portrait already committed for the
-continuous-edit test (``tests/continuous_edit_test/files/winry_joy.png``)
-so no new fixture is needed.
-
-Requirements: GIMP MCP plugin must be running on ``localhost:9877``.
+Requires the GIMP MCP plugin running on localhost:9877.
 Exits 0 on pass, 1 on fail.
 """
 import json
@@ -40,11 +17,7 @@ TEST_IMAGE = os.path.join(HERE, 'continuous_edit_test', 'files', 'winry_joy.png'
 # ── transport ─────────────────────────────────────────────────────────────
 
 def send(msg, timeout=30):
-    """Send one JSON message to the GIMP MCP socket and return the reply.
-
-    The plugin emits newline-delimited JSON; we keep reading until
-    ``json.loads`` succeeds on the accumulated buffer.
-    """
+    """Send one JSON message to the MCP socket and return the reply."""
     s = socket.socket()
     s.settimeout(timeout)
     s.connect((HOST, PORT))
@@ -71,12 +44,12 @@ def send(msg, timeout=30):
 
 
 def cmd(t, params=None):
-    """Convenience wrapper: send a ``{type, params}`` command."""
+    """Send a {type, params} command."""
     return send({'type': t, 'params': params or {}})
 
 
 def fail(msg):
-    """Abort the test with a clear failure banner on stderr."""
+    """Abort with a failure banner on stderr."""
     print(f"FAIL: {msg}", file=sys.stderr)
     sys.exit(1)
 
@@ -84,14 +57,7 @@ def fail(msg):
 # ── test steps ────────────────────────────────────────────────────────────
 
 def open_test_image():
-    """Open the test image and return ``(target_index, opened_id)``.
-
-    Uses the ``image_id`` returned by ``open_image`` to find the matching
-    entry in ``list_images``. This is the authoritative handle — matching
-    by path suffix alone can pick a stale duplicate in a persistent GIMP
-    session. Path-suffix matching is kept as a fallback only for the
-    case where ``image_id`` is missing from the ``open_image`` response.
-    """
+    """Open the test image and return (target_index, opened_id)."""
     if not os.path.exists(TEST_IMAGE):
         fail(f"test image missing: {TEST_IMAGE}")
 
@@ -107,6 +73,8 @@ def open_test_image():
     if not images:
         fail("no images after open_image")
 
+    # Match by image_id (authoritative) — path-suffix can hit a stale
+    # duplicate in a persistent GIMP session.
     target_index = None
     if opened_id is not None:
         target_index = _find_index_by(images, 'image_id', opened_id)
@@ -120,7 +88,6 @@ def open_test_image():
 
 
 def _find_index_by(images, key, value):
-    """Return the index of the image whose ``key`` equals ``value``, or None."""
     for i, info in enumerate(images):
         if isinstance(info, dict) and info.get(key) == value:
             return i
@@ -128,7 +95,6 @@ def _find_index_by(images, key, value):
 
 
 def _find_index_by_suffix(images, suffix):
-    """Return the index of the image whose ``file_path`` ends with ``suffix``."""
     for i, info in enumerate(images):
         if isinstance(info, dict) and info.get('file_path', '').endswith(suffix):
             return i
@@ -136,7 +102,7 @@ def _find_index_by_suffix(images, suffix):
 
 
 def call_add_text(target_index):
-    """Invoke ``add_text`` with concrete parameters and return the response."""
+    """Invoke add_text and return the response results dict."""
     print("Calling add_text with real parameters...")
     r = cmd('add_text', {
         'image_index': target_index,
@@ -154,20 +120,14 @@ def call_add_text(target_index):
 
 
 def assert_real_metadata(results):
-    """Verify ``add_text`` returned real values, not issue #15 placeholders.
-
-    ``layer_id`` must be **strictly positive**. A real ``Gimp.Drawable``
-    id is never 0, so accepting 0 would let a default-int return slip
-    through the check just as the old ``-1`` sentinel did.
-
-    Returns ``(layer_id, layer_name, text_width, text_height)`` on
-    success; aborts via :func:`fail` on any placeholder.
-    """
+    """Verify add_text returned real values, not placeholders."""
     layer_id   = results.get('layer_id')
     layer_name = results.get('layer_name')
     text_w     = results.get('text_width')
     text_h     = results.get('text_height')
 
+    # layer_id must be strictly positive — a real Gimp.Drawable id is never 0,
+    # so accepting 0 would let a default-int slip through like the old -1 did.
     if not isinstance(layer_id, int) or layer_id <= 0:
         fail(f"layer_id is placeholder: {layer_id!r} (expected positive int)")
     if not layer_name or layer_name == 'unknown':
@@ -180,22 +140,13 @@ def assert_real_metadata(results):
 
 
 def assert_chainable(target_index, layer_id, layer_name):
-    """Verify the returned handle is visible to ``list_layers``.
-
-    Requires a single listed layer whose ``id`` **and** ``name`` both
-    match the metadata we got back. Matching on either-or would happily
-    succeed against an unrelated layer that happens to share a
-    (non-unique) name, which could mask a real bug where the returned
-    ``id`` does not resolve to the new text layer.
-
-    The whole point of issue #15 is that clients must be able to chain
-    further operations on the new text layer — only a full id+name
-    match actually proves that.
-    """
+    """Verify the returned handle is visible to list_layers."""
     ll = cmd('list_layers', {'image_index': target_index})
     if ll.get('status') != 'success':
         fail(f"list_layers failed: {ll.get('error', '')}")
 
+    # Require both id AND name to match — id-or-name could pass against an
+    # unrelated layer that happens to share a non-unique name.
     layers = (ll.get('results') or {}).get('layers') or []
     match  = next((lyr for lyr in layers
                    if lyr.get('id') == layer_id and lyr.get('name') == layer_name),
@@ -208,17 +159,7 @@ def assert_chainable(target_index, layer_id, layer_name):
 # ── entry point ───────────────────────────────────────────────────────────
 
 def close_image_if_open(target_index):
-    """Close the test image to avoid polluting the persistent GIMP session.
-
-    Safe to call even if image opening failed — ``target_index`` may be
-    ``None``, in which case we skip cleanup.
-
-    Cleanup is best-effort: we issue the ``close_image`` command and log
-    any non-success response to stderr without raising. That way a
-    server-side close bug (GIMP 3.x display-enumeration quirks etc.)
-    surfaces in the test output for follow-up, but does not mask the
-    actual test result that triggered the ``finally``.
-    """
+    """Close the test image so a persistent GIMP session stays clean."""
     if target_index is None:
         return
     try:

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
 """Regression test for issue #15 — add_text must return real layer metadata.
 
-Before the fix, _add_text returned placeholder values when PDB return-value
-unpacking failed:
+Before the fix, ``_add_text`` returned placeholder values when PDB
+return-value unpacking failed::
+
     {'layer_name': 'unknown', 'layer_id': -1, 'text_width': 0, ...}
-while status was still 'success', so any follow-up op targeting the layer
-by name/id would fail silently.
 
-This test opens tests/continuous_edit_test/files/winry_joy.png, adds a text
-layer, and asserts:
-  - status == 'success'
-  - layer_id is a positive int (not -1)
-  - layer_name is not 'unknown' and not empty
-  - text_width / text_height are positive (the layer actually rendered)
-  - list_layers sees the new layer with the same id/name — proving the
-    returned handle is usable for chaining (the whole point of issue #15).
+while ``status`` was still ``'success'``, so any follow-up op targeting
+the layer by id/name would fail silently.
 
-Requires the GIMP MCP plugin running on localhost:9877.
-Exit 0 on pass, 1 on fail.
+What this test proves
+---------------------
+
+1. ``add_text`` responds with ``status == 'success'``.
+2. The returned ``layer_id``/``layer_name``/``text_width``/``text_height``
+   are **real values**, not the old ``-1`` / ``'unknown'`` / ``0``
+   sentinels.
+3. ``list_layers`` can see a layer that matches the returned id *and*
+   name — proving the handle is actually chainable, which is the whole
+   point of issue #15.
+
+The test reuses the character portrait already committed for the
+continuous-edit test (``tests/continuous_edit_test/files/winry_joy.png``)
+so no new fixture is needed.
+
+Requirements: GIMP MCP plugin must be running on ``localhost:9877``.
+Exits 0 on pass, 1 on fail.
 """
 import json
 import os
@@ -25,11 +33,18 @@ import socket
 import sys
 
 HOST, PORT = '127.0.0.1', 9877
-HERE = os.path.dirname(os.path.abspath(__file__))
+HERE       = os.path.dirname(os.path.abspath(__file__))
 TEST_IMAGE = os.path.join(HERE, 'continuous_edit_test', 'files', 'winry_joy.png')
 
 
+# ── transport ─────────────────────────────────────────────────────────────
+
 def send(msg, timeout=30):
+    """Send one JSON message to the GIMP MCP socket and return the reply.
+
+    The plugin emits newline-delimited JSON; we keep reading until
+    ``json.loads`` succeeds on the accumulated buffer.
+    """
     s = socket.socket()
     s.settimeout(timeout)
     s.connect((HOST, PORT))
@@ -56,15 +71,27 @@ def send(msg, timeout=30):
 
 
 def cmd(t, params=None):
+    """Convenience wrapper: send a ``{type, params}`` command."""
     return send({'type': t, 'params': params or {}})
 
 
 def fail(msg):
+    """Abort the test with a clear failure banner on stderr."""
     print(f"FAIL: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
-def main():
+# ── test steps ────────────────────────────────────────────────────────────
+
+def open_test_image():
+    """Open the test image and return ``(target_index, opened_id)``.
+
+    Uses the ``image_id`` returned by ``open_image`` to find the matching
+    entry in ``list_images``. This is the authoritative handle — matching
+    by path suffix alone can pick a stale duplicate in a persistent GIMP
+    session. Path-suffix matching is kept as a fallback only for the
+    case where ``image_id`` is missing from the ``open_image`` response.
+    """
     if not os.path.exists(TEST_IMAGE):
         fail(f"test image missing: {TEST_IMAGE}")
 
@@ -73,36 +100,43 @@ def main():
     if r.get('status') != 'success':
         fail(f"open_image: {r.get('error', '')}")
 
-    # open_image returns the new image_id at the top level or under
-    # results — this is the authoritative handle we must match against
-    # list_images. In a persistent GIMP session, repeated runs can leave
-    # several winry_joy.png images open; picking by path suffix alone
-    # would happily target a stale one, so prefer image_id and only
-    # fall back to path matching if image_id is missing.
-    opened_id = r.get('image_id')
-    if opened_id is None:
-        opened_id = (r.get('results') or {}).get('image_id')
+    opened_id = r.get('image_id') or (r.get('results') or {}).get('image_id')
 
-    li = cmd('list_images', {})
+    li     = cmd('list_images', {})
     images = (li.get('results') or {}).get('images') or []
     if not images:
         fail("no images after open_image")
 
     target_index = None
     if opened_id is not None:
-        for i, info in enumerate(images):
-            if isinstance(info, dict) and info.get('image_id') == opened_id:
-                target_index = i
-                break
+        target_index = _find_index_by(images, 'image_id', opened_id)
     if target_index is None:
-        for i, info in enumerate(images):
-            if isinstance(info, dict) and info.get('file_path', '').endswith('winry_joy.png'):
-                target_index = i
-                break
+        target_index = _find_index_by_suffix(images, 'winry_joy.png')
     if target_index is None:
         target_index = 0
-    print(f"Using image_index={target_index} (image_id={opened_id})")
 
+    print(f"Using image_index={target_index} (image_id={opened_id})")
+    return target_index, opened_id
+
+
+def _find_index_by(images, key, value):
+    """Return the index of the image whose ``key`` equals ``value``, or None."""
+    for i, info in enumerate(images):
+        if isinstance(info, dict) and info.get(key) == value:
+            return i
+    return None
+
+
+def _find_index_by_suffix(images, suffix):
+    """Return the index of the image whose ``file_path`` ends with ``suffix``."""
+    for i, info in enumerate(images):
+        if isinstance(info, dict) and info.get('file_path', '').endswith(suffix):
+            return i
+    return None
+
+
+def call_add_text(target_index):
+    """Invoke ``add_text`` with concrete parameters and return the response."""
     print("Calling add_text with real parameters...")
     r = cmd('add_text', {
         'image_index': target_index,
@@ -114,17 +148,22 @@ def main():
         'color':       '#ff0000',
     })
     print(f"  response: {json.dumps(r)[:300]}")
-
     if r.get('status') != 'success':
         fail(f"add_text reported error: {r.get('error', '')}")
+    return r.get('results') or {}
 
-    results = r.get('results') or {}
-    layer_id    = results.get('layer_id')
-    layer_name  = results.get('layer_name')
-    text_w      = results.get('text_width')
-    text_h      = results.get('text_height')
 
-    # Core assertions for issue #15
+def assert_real_metadata(results):
+    """Verify ``add_text`` returned real values, not issue #15 placeholders.
+
+    Returns ``(layer_id, layer_name, text_width, text_height)`` on
+    success; aborts via :func:`fail` on any placeholder.
+    """
+    layer_id   = results.get('layer_id')
+    layer_name = results.get('layer_name')
+    text_w     = results.get('text_width')
+    text_h     = results.get('text_height')
+
     if not isinstance(layer_id, int) or layer_id < 0:
         fail(f"layer_id is placeholder: {layer_id!r} (expected positive int)")
     if not layer_name or layer_name == 'unknown':
@@ -133,20 +172,38 @@ def main():
         fail(f"text_width is placeholder/zero: {text_w!r}")
     if not isinstance(text_h, int) or text_h <= 0:
         fail(f"text_height is placeholder/zero: {text_h!r}")
+    return layer_id, layer_name, text_w, text_h
 
-    # Prove the handle is chainable: list_layers must see the returned
-    # layer_id and layer_name on the current image.
+
+def assert_chainable(target_index, layer_id, layer_name):
+    """Verify the returned handle is visible to ``list_layers``.
+
+    The whole point of issue #15 is that clients must be able to chain
+    further operations on the new text layer. If ``list_layers`` can find
+    a layer matching the returned id/name, the handle is usable.
+    """
     ll = cmd('list_layers', {'image_index': target_index})
     if ll.get('status') != 'success':
         fail(f"list_layers failed: {ll.get('error', '')}")
+
     layers = (ll.get('results') or {}).get('layers') or []
-    match = next((lyr for lyr in layers
-                  if lyr.get('id') == layer_id or lyr.get('name') == layer_name),
-                 None)
+    match  = next((lyr for lyr in layers
+                   if lyr.get('id') == layer_id or lyr.get('name') == layer_name),
+                  None)
     if match is None:
         fail(f"returned layer (id={layer_id}, name={layer_name!r}) not in list_layers: {layers}")
+    return match
 
-    print(f"PASS add_text: layer_id={layer_id} name={layer_name!r} size={text_w}x{text_h}")
+
+# ── entry point ───────────────────────────────────────────────────────────
+
+def main():
+    target_index, _opened_id = open_test_image()
+    results                  = call_add_text(target_index)
+    layer_id, layer_name, w, h = assert_real_metadata(results)
+    match                    = assert_chainable(target_index, layer_id, layer_name)
+
+    print(f"PASS add_text: layer_id={layer_id} name={layer_name!r} size={w}x{h}")
     print(f"PASS list_layers confirms layer is chainable: {match}")
     sys.exit(0)
 

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -73,19 +73,35 @@ def main():
     if r.get('status') != 'success':
         fail(f"open_image: {r.get('error', '')}")
 
-    # Use image_index 0 — this will be the most recently opened image in
-    # many impls, but we check list_images to be safe.
+    # open_image returns the new image_id at the top level or under
+    # results — this is the authoritative handle we must match against
+    # list_images. In a persistent GIMP session, repeated runs can leave
+    # several winry_joy.png images open; picking by path suffix alone
+    # would happily target a stale one, so prefer image_id and only
+    # fall back to path matching if image_id is missing.
+    opened_id = r.get('image_id')
+    if opened_id is None:
+        opened_id = (r.get('results') or {}).get('image_id')
+
     li = cmd('list_images', {})
     images = (li.get('results') or {}).get('images') or []
     if not images:
         fail("no images after open_image")
-    # Prefer the image whose path matches
-    target_index = 0
-    for i, info in enumerate(images):
-        if isinstance(info, dict) and info.get('file_path', '').endswith('winry_joy.png'):
-            target_index = i
-            break
-    print(f"Using image_index={target_index}")
+
+    target_index = None
+    if opened_id is not None:
+        for i, info in enumerate(images):
+            if isinstance(info, dict) and info.get('image_id') == opened_id:
+                target_index = i
+                break
+    if target_index is None:
+        for i, info in enumerate(images):
+            if isinstance(info, dict) and info.get('file_path', '').endswith('winry_joy.png'):
+                target_index = i
+                break
+    if target_index is None:
+        target_index = 0
+    print(f"Using image_index={target_index} (image_id={opened_id})")
 
     print("Calling add_text with real parameters...")
     r = cmd('add_text', {

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -207,15 +207,42 @@ def assert_chainable(target_index, layer_id, layer_name):
 
 # ── entry point ───────────────────────────────────────────────────────────
 
-def main():
-    target_index, _opened_id = open_test_image()
-    results                  = call_add_text(target_index)
-    layer_id, layer_name, w, h = assert_real_metadata(results)
-    match                    = assert_chainable(target_index, layer_id, layer_name)
+def close_image_if_open(target_index):
+    """Close the test image to avoid polluting the persistent GIMP session.
 
-    print(f"PASS add_text: layer_id={layer_id} name={layer_name!r} size={w}x{h}")
-    print(f"PASS list_layers confirms layer is chainable: {match}")
-    sys.exit(0)
+    Safe to call even if image opening failed — ``target_index`` may be
+    ``None``, in which case we skip cleanup.
+
+    Cleanup is best-effort: we issue the ``close_image`` command and log
+    any non-success response to stderr without raising. That way a
+    server-side close bug (GIMP 3.x display-enumeration quirks etc.)
+    surfaces in the test output for follow-up, but does not mask the
+    actual test result that triggered the ``finally``.
+    """
+    if target_index is None:
+        return
+    try:
+        r = cmd('close_image', {'image_index': target_index, 'save_first': False})
+        if r.get('status') != 'success':
+            print(f"  (cleanup) close_image non-success: {r.get('error', '')[:200]}",
+                  file=sys.stderr)
+    except Exception as e:
+        print(f"  (cleanup) close_image transport error: {e}", file=sys.stderr)
+
+
+def main():
+    target_index = None
+    try:
+        target_index, _opened_id = open_test_image()
+        results                  = call_add_text(target_index)
+        layer_id, layer_name, w, h = assert_real_metadata(results)
+        match                    = assert_chainable(target_index, layer_id, layer_name)
+
+        print(f"PASS add_text: layer_id={layer_id} name={layer_name!r} size={w}x{h}")
+        print(f"PASS list_layers confirms layer is chainable: {match}")
+        sys.exit(0)
+    finally:
+        close_image_if_open(target_index)
 
 
 if __name__ == '__main__':

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -165,8 +165,8 @@ def close_image_if_open(target_index):
     try:
         r = cmd('close_image', {'image_index': target_index, 'save_first': False})
         if r.get('status') != 'success':
-            print(f"  (cleanup) close_image non-success: {r.get('error', '')[:200]}",
-                  file=sys.stderr)
+            err = str(r.get('error') or '')[:200]
+            print(f"  (cleanup) close_image non-success: {err}", file=sys.stderr)
     except Exception as e:
         print(f"  (cleanup) close_image transport error: {e}", file=sys.stderr)
 

--- a/tests/test_add_text_metadata.py
+++ b/tests/test_add_text_metadata.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Regression test for issue #15 — add_text must return real layer metadata.
+
+Before the fix, _add_text returned placeholder values when PDB return-value
+unpacking failed:
+    {'layer_name': 'unknown', 'layer_id': -1, 'text_width': 0, ...}
+while status was still 'success', so any follow-up op targeting the layer
+by name/id would fail silently.
+
+This test opens tests/continuous_edit_test/files/winry_joy.png, adds a text
+layer, and asserts:
+  - status == 'success'
+  - layer_id is a positive int (not -1)
+  - layer_name is not 'unknown' and not empty
+  - text_width / text_height are positive (the layer actually rendered)
+  - list_layers sees the new layer with the same id/name — proving the
+    returned handle is usable for chaining (the whole point of issue #15).
+
+Requires the GIMP MCP plugin running on localhost:9877.
+Exit 0 on pass, 1 on fail.
+"""
+import json
+import os
+import socket
+import sys
+
+HOST, PORT = '127.0.0.1', 9877
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEST_IMAGE = os.path.join(HERE, 'continuous_edit_test', 'files', 'winry_joy.png')
+
+
+def send(msg, timeout=30):
+    s = socket.socket()
+    s.settimeout(timeout)
+    s.connect((HOST, PORT))
+    s.send(json.dumps(msg).encode() + b'\n')
+    buf = b''
+    while True:
+        try:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            buf += chunk
+            try:
+                json.loads(buf.decode())
+                break
+            except json.JSONDecodeError:
+                continue
+        except socket.timeout:
+            break
+    s.close()
+    try:
+        return json.loads(buf.decode().strip())
+    except json.JSONDecodeError:
+        return {'status': 'error', 'error': 'parse: ' + buf.decode()[:200]}
+
+
+def cmd(t, params=None):
+    return send({'type': t, 'params': params or {}})
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if not os.path.exists(TEST_IMAGE):
+        fail(f"test image missing: {TEST_IMAGE}")
+
+    print(f"Opening test image: {TEST_IMAGE}")
+    r = cmd('open_image', {'file_path': TEST_IMAGE})
+    if r.get('status') != 'success':
+        fail(f"open_image: {r.get('error', '')}")
+
+    # Use image_index 0 — this will be the most recently opened image in
+    # many impls, but we check list_images to be safe.
+    li = cmd('list_images', {})
+    images = (li.get('results') or {}).get('images') or []
+    if not images:
+        fail("no images after open_image")
+    # Prefer the image whose path matches
+    target_index = 0
+    for i, info in enumerate(images):
+        if isinstance(info, dict) and info.get('file_path', '').endswith('winry_joy.png'):
+            target_index = i
+            break
+    print(f"Using image_index={target_index}")
+
+    print("Calling add_text with real parameters...")
+    r = cmd('add_text', {
+        'image_index': target_index,
+        'text':        'Issue15',
+        'x':           10,
+        'y':           10,
+        'font':        'Sans',
+        'size':        24,
+        'color':       '#ff0000',
+    })
+    print(f"  response: {json.dumps(r)[:300]}")
+
+    if r.get('status') != 'success':
+        fail(f"add_text reported error: {r.get('error', '')}")
+
+    results = r.get('results') or {}
+    layer_id    = results.get('layer_id')
+    layer_name  = results.get('layer_name')
+    text_w      = results.get('text_width')
+    text_h      = results.get('text_height')
+
+    # Core assertions for issue #15
+    if not isinstance(layer_id, int) or layer_id < 0:
+        fail(f"layer_id is placeholder: {layer_id!r} (expected positive int)")
+    if not layer_name or layer_name == 'unknown':
+        fail(f"layer_name is placeholder: {layer_name!r}")
+    if not isinstance(text_w, int) or text_w <= 0:
+        fail(f"text_width is placeholder/zero: {text_w!r}")
+    if not isinstance(text_h, int) or text_h <= 0:
+        fail(f"text_height is placeholder/zero: {text_h!r}")
+
+    # Prove the handle is chainable: list_layers must see the returned
+    # layer_id and layer_name on the current image.
+    ll = cmd('list_layers', {'image_index': target_index})
+    if ll.get('status') != 'success':
+        fail(f"list_layers failed: {ll.get('error', '')}")
+    layers = (ll.get('results') or {}).get('layers') or []
+    match = next((lyr for lyr in layers
+                  if lyr.get('id') == layer_id or lyr.get('name') == layer_name),
+                 None)
+    if match is None:
+        fail(f"returned layer (id={layer_id}, name={layer_name!r}) not in list_layers: {layers}")
+
+    print(f"PASS add_text: layer_id={layer_id} name={layer_name!r} size={text_w}x{text_h}")
+    print(f"PASS list_layers confirms layer is chainable: {match}")
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes #15.

## Problem

`add_text` was returning placeholder metadata while reporting `status=success`:

```json
{"status": "success",
 "results": {"layer_name": "unknown", "layer_id": -1,
             "text_width": 0, "text_height": 0, "position": [10, 10]}}
```

Root cause surfaced while probing a live GIMP 3.2.2 runtime:

1. `_add_text` was looking up `gimp-text-fontname` — a **GIMP 2.x** PDB procedure. On GIMP 3.2 `pdb.lookup_procedure("gimp-text-fontname")` returns `None`, so the whole branch was skipped and `text_layer` stayed `None`.
2. The response assembly then fell through to `"unknown"`/`-1`/`0` defaults but still reported `status=success`, so callers had no signal that anything was wrong.
3. Independently, `Gimp.Font.get_by_name("Sans")` returns `None` on 3.2 (the matching font is `"Sans-serif"`) — so even the native API path would have failed on the default font value.

Because the returned `layer_id`/`layer_name` were fake, any follow-up operation that tried to chain on the new text layer (move, rotate, reorder, recolor) would target the wrong layer or fail lookup entirely.

## Fix

Rewrite `_add_text` for GIMP 3.2 (`gimp-mcp-plugin.py`):

- **Font resolution with fallbacks.** Try the exact name, then common aliases (`"Sans"` → `"Sans-serif"`, `"<name> Regular"`, hyphenated), then `"Sans-serif"`/`"Serif"`/`"Monospace"`, and finally the first available font from `Gimp.fonts_get_list("")`. Stale font names no longer cause silent failure.
- **Primary path:** `Gimp.TextLayer.new(image, text, font_obj, size, Gimp.Unit.pixel())` + `image.insert_layer()` + `set_offsets()` + `gimp-text-layer-set-color` PDB proc.
- **Fallback path:** `gimp-text-font` PDB procedure (the 3.x replacement for `gimp-text-fontname`; takes a `GimpFont` object rather than a string).
- **Robust layer identification.** Snapshot the layer-id set before creation; if neither path returned a handle directly, diff against the post-call layer list to find the newly inserted layer. This is resilient to PDB return-tuple shape differences across GIMP 3.x point releases.
- **No more placeholder success.** If no layer was actually created, return `status=error` with an explanatory message instead of `status=success` with fake values.

## Test

Added `tests/test_add_text_metadata.py`. It opens `tests/continuous_edit_test/files/winry_joy.png`, calls `add_text`, and asserts:

- `status == "success"`
- `layer_id` is a positive int (not `-1`)
- `layer_name` is not `"unknown"` and not empty
- `text_width > 0` and `text_height > 0` (the layer actually rendered)
- `list_layers` sees the returned id/name — proving the handle is chainable (the core requirement of the issue)

## Verification on GIMP 3.2.2

- `tests/test_add_text_metadata.py` — **PASS** (`layer_id=3 name='Issue15' size=95x31`, cross-checked by `list_layers`)
- `run_tests.py` — **56/56 PASSED**, including Cat 7 `add_text` which now shows `layer_name: 'Hello', layer_id: 13, text_width: 29, ...`
- `tests/continuous_edit_test/continuous_edit_test.py` — **SUCCESS** (full BG removal → recolor → composite → export pipeline)

## Quality gates

- `ruff check .` — clean
- `python -m py_compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved text insertion to prefer native GIMP 3 creation with robust fallbacks across versions.

* **Bug Fixes**
  * add_text returns accurate, non-placeholder text layer metadata: real layer name, ID, width, and height.
  * Better error reporting when text layer creation fails and more reliable detection of newly created layers.

* **Tests**
  * Added end-to-end regression test ensuring add_text returns real, resolvable layer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->