### PR TITLE
Fix select_by_color silently no-opping on GIMP 3.2

### DIFF
--- a/gimp-mcp-plugin.py
+++ b/gimp-mcp-plugin.py
@@ -2376,18 +2376,26 @@ class MCPPlugin(Gimp.PlugIn):
             op = self._channel_ops_from_string(operation)
             color = Gegl.Color.new(color_str)
             pdb = Gimp.get_pdb()
-            proc = pdb.lookup_procedure("gimp-by-color-select")
-            if proc:
+            proc = pdb.lookup_procedure("gimp-image-select-color")
+            if proc is None:
+                raise RuntimeError(
+                    "PDB procedure 'gimp-image-select-color' not found"
+                )
+            Gimp.context_push()
+            try:
+                Gimp.context_set_antialias(True)
+                Gimp.context_set_feather(False)
+                Gimp.context_set_sample_threshold_int(threshold)
+                Gimp.context_set_sample_merged(False)
+                Gimp.context_set_sample_transparent(False)
                 cfg = proc.create_config()
-                cfg.set_property("drawable",    drawable)
-                cfg.set_property("color",       color)
-                cfg.set_property("threshold",   threshold)
-                cfg.set_property("operation",   op)
-                cfg.set_property("antialias",   True)
-                cfg.set_property("feather",     False)
-                cfg.set_property("feather-radius", 0.0)
-                cfg.set_property("sample-merged", False)
+                cfg.set_property("image",     image)
+                cfg.set_property("drawable",  drawable)
+                cfg.set_property("color",     color)
+                cfg.set_property("operation", op)
                 proc.run(cfg)
+            finally:
+                Gimp.context_pop()
             Gimp.displays_flush()
             return {"status": "success", "results": {"status": "success"}}
         except Exception as e:


### PR DESCRIPTION
## Summary

`select_by_color` looks up the PDB procedure `gimp-by-color-select`, which **does not exist on GIMP 3.2** — it was renamed to `gimp-image-select-color`. The current code guards the call with `if proc:` and silently falls through to `return {"status": "success", ...}` when the lookup returns `None`, so no selection is ever created, but the caller is told the operation succeeded.

This is dangerous because downstream tools assume a selection exists. In particular, `fill_selection` with `fill_type='transparent'` calls `Gimp.Drawable.edit_clear(drawable)`, which **clears the entire layer when no selection is active**. So a typical "remove black background" workflow

```
add_alpha → select_by_color('#000000') → fill_selection(transparent)
```

silently wipes the whole image instead of just the BG.

## Fix

- Use the GIMP 3.2 procedure name `gimp-image-select-color`.
- Raise `RuntimeError` when the lookup returns `None` instead of silently no-opping, so future renames are caught immediately.
- The new procedure config exposes only `image / drawable / color / operation`; threshold, antialias, feather, and sample-merged are read from the GIMP context. Set them via `Gimp.context_*` inside a `context_push() / context_pop()` pair so we don't leak settings into the rest of the session.

## How I hit this

Running an MCP-driven "remove black background, export transparent PNG for a black t-shirt print" pipeline on a JPEG. After `select_by_color('#000000', threshold=30)` followed by `fill_selection(fill_type='transparent')`, every pixel ended up with `alpha=0` (RGB preserved). Confirmed with `pdb.procedure_exists('gimp-by-color-select')` → `False` and `pdb.procedure_exists('gimp-image-select-color')` → `True` on GIMP 3.2.2.

## Note on existing test coverage

`run_tests.py:92` exercises `select_by_color`, but only checks that the response status is `success`. Since the buggy path returns success without doing anything, the test passes against a broken plugin. Worth a follow-up to assert the selection is non-empty (e.g. via `Gimp.Selection.is_empty()`), but I left test changes out of this PR to keep the diff minimal.

## Test plan

- [x] On GIMP 3.2.2, run `select_by_color({'color': '#000000', 'threshold': 30})` on a black-background image and verify the selection bounds are non-empty (`Gimp.Selection.bounds(image)` returns `non_empty=True`).
- [x] Run `fill_selection({'fill_type': 'transparent'})` after the select and confirm only the BG pixels go to `alpha=0`; foreground pixels keep `alpha=1.0`.
- [x] `ruff check gimp-mcp-plugin.py` — clean.
- [ ] Maintainer sanity-check on a non-snap / different-distro GIMP 3.2 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the "Select by Color" tool's internal implementation for better stability and consistency.
  * Enhanced error handling to explicitly fail when the required procedure is unavailable.
  * Refined selection parameter handling with optimized defaults (antialias enabled, feather disabled, integer-based threshold).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->