### PR TITLE
Assert select_by_color creates a non-empty selection

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -45,6 +45,17 @@ def t(name, r):
     print(f"  {'PASS' if ok else 'FAIL'} {name}: {detail}")
     return r
 
+def chk(name, ok, detail=''):
+    """Assert an arbitrary boolean condition (beyond response status)."""
+    global passed, failed
+    if ok:
+        passed += 1
+    else:
+        failed += 1
+        failures.append((name, str(detail)[:90]))
+    print(f"  {'PASS' if ok else 'FAIL'} {name}: {str(detail)[:65]}")
+    return ok
+
 # Setup
 r = cmd('new_canvas', {'width': 200, 'height': 200, 'fill': 'white'})
 img_id = r.get('image_id') or r.get('results', {}).get('image_id')
@@ -89,7 +100,14 @@ print()
 print("=== Cat 4: Selections ===")
 t('select_rect',    cmd('select_rectangle', {'image_index': 0, 'x': 10, 'y': 10, 'width': 40, 'height': 40}))
 t('select_ellipse', cmd('select_ellipse',   {'image_index': 0, 'x': 10, 'y': 10, 'width': 40, 'height': 40}))
+# Regression #23: select_by_color must actually create a selection, not
+# silently no-op while reporting success. Fill a known color and clear any
+# prior selection first, so a leftover selection can't mask a no-op.
+cmd('fill_layer',  {'image_index': 0, 'color': '#ffffff'})
+cmd('select_none', {'image_index': 0})
 t('select_color',   cmd('select_by_color',  {'image_index': 0, 'color': '#ffffff'}))
+_sel = cmd('get_selection_bounds', {'image_index': 0})
+chk('select_color_nonempty', _sel.get('results', {}).get('has_selection') is True, _sel.get('results'))
 t('select_all',     cmd('select_all',       {'image_index': 0}))
 t('select_none',    cmd('select_none',      {'image_index': 0}))
 t('invert_sel',     cmd('invert_selection', {'image_index': 0}))


### PR DESCRIPTION
Follow-up to #23. The `select_by_color` check in `run_tests.py` only asserted the response status, so the silent no-op fixed in #23 (PDB lookup miss returning `success` without selecting anything) would still pass.

This fills a known color, clears any prior selection, then asserts the selection is non-empty after `select_by_color`, so a silent no-op fails instead of passing.

Verified against GIMP 3.2.4: full `run_tests.py` suite 57/57 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the color selection feature to ensure selection boundaries are properly detected and verified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maorcc/gimp-mcp/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->