### PR TITLE
Address CodeRabbit nitpicks from #25 and #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ BASE="$HOME/Library/Application Support/GIMP"     # macOS
 
 # Auto-select the newest GIMP 3.x config directory (3.0, 3.2, 3.4, ...):
 GIMP_DIR="$(ls -d "$BASE"/3.* 2>/dev/null | sort -V | tail -1)"
+if [ -z "$GIMP_DIR" ]; then
+  echo "No GIMP 3.x config dir found under $BASE — launch GIMP once, then re-run." >&2
+  exit 1
+fi
 mkdir -p "$GIMP_DIR/plug-ins/gimp-mcp-plugin"
 cp gimp-mcp-plugin.py "$GIMP_DIR/plug-ins/gimp-mcp-plugin/"
 chmod +x "$GIMP_DIR/plug-ins/gimp-mcp-plugin/gimp-mcp-plugin.py"
@@ -117,7 +121,7 @@ echo "Installed into: $GIMP_DIR/plug-ins/gimp-mcp-plugin"
 ```
 
 **Windows:**
-```
+```text
 %APPDATA%\GIMP\<VERSION>\plug-ins\gimp-mcp-plugin\gimp-mcp-plugin.py
 ```
 Replace `<VERSION>` with your GIMP major.minor (e.g. `3.2`). No chmod needed on Windows. Just copy and restart GIMP.

--- a/run_tests.py
+++ b/run_tests.py
@@ -103,8 +103,9 @@ t('select_ellipse', cmd('select_ellipse',   {'image_index': 0, 'x': 10, 'y': 10,
 # Regression #23: select_by_color must actually create a selection, not
 # silently no-op while reporting success. Fill a known color and clear any
 # prior selection first, so a leftover selection can't mask a no-op.
-cmd('fill_layer',  {'image_index': 0, 'color': '#ffffff'})
-cmd('select_none', {'image_index': 0})
+# Assert the setup itself succeeds so a broken fill can't skew the real check.
+t('select_setup_fill', cmd('fill_layer',  {'image_index': 0, 'color': '#ffffff'}))
+t('select_setup_none', cmd('select_none', {'image_index': 0}))
 t('select_color',   cmd('select_by_color',  {'image_index': 0, 'color': '#ffffff'}))
 _sel = cmd('get_selection_bounds', {'image_index': 0})
 chk('select_color_nonempty', _sel.get('results', {}).get('has_selection') is True, _sel.get('results'))


### PR DESCRIPTION
Follow-up applying the CodeRabbit nitpicks left on #25 and #26 (both already merged).

- **README** (`#26`): fail fast if no `GIMP/3.x` config dir is found — an empty `GIMP_DIR` would otherwise `mkdir` at the filesystem root.
- **README** (`#26`): add a `text` language tag to the Windows path code fence.
- **run_tests.py** (`#25`): assert the `select_by_color` setup (`fill_layer`, `select_none`) succeeds, so a broken setup surfaces distinctly from the regression check itself.

Verified against GIMP 3.2.4: full `run_tests.py` suite 59/59 passing; `ruff` clean; guard snippet passes `bash -n`.